### PR TITLE
fix saving path for osx

### DIFF
--- a/main.js
+++ b/main.js
@@ -37,10 +37,11 @@ app.on('activate', () => {
 });
 
 exports.getAppPath = function() {
-  const path = app.getPath('exe');
   if (process.platform == 'darwin') {
-    return path + '/../../../..';
+    const path = app.getPath('userData');
+    return path;
   } else {
+    const path = app.getPath('exe');
     return path + '/..';
   }
 };


### PR DESCRIPTION
Can't create directory on application dir on OSX....

save to `~/Library/Application\ Support/iksm-fetcher/results`